### PR TITLE
Branch 2.8.0

### DIFF
--- a/bin/save-version.sh
+++ b/bin/save-version.sh
@@ -21,7 +21,7 @@
 # Note: for internal (aka pre-release) versions, the version should have
 # "-INTERNAL" appended. Parts of the code will look for this to distinguish
 # between released and internal versions.
-VERSION=2.8.0-SNAPSHOT
+VERSION=2.8.0-RELEASE
 GIT_HASH=$(git rev-parse HEAD 2> /dev/null)
 if [ -z $GIT_HASH ]
 then

--- a/docs/topics/impala_intro.xml
+++ b/docs/topics/impala_intro.xml
@@ -52,7 +52,10 @@ under the License.
       <note>
         Impala was accepted into the Apache incubator on December 2, 2015.
         In places where the documentation formerly referred to <q>Cloudera Impala</q>,
-        now the official name is <q>Apache Impala (incubating)</q>.
+        now the official name is <q>Apache Impala (incubating)</q>. As of January 2016,
+        the Impala community is working on excising the Cloudera-specific documentation
+        from this manual. While that is ongoing, there are still some outdated or
+        off-topic parts of this manual.
       </note>
 
   </conbody>


### PR DESCRIPTION
I would like to register my first pull request for Impala. We are using it in production almost 3 years.
I would like to suggest to improve the behaviour of compute incremental stats. 
We have a very very large table, initialy migrated from other cluster and we had to create stats on the table. Compute incremental stats after 4 hours failed (skipped), and in that time based on HDFS reads almost 90% of the table was scanned. Unfortunately Impala didnt stored the partitions statisics (daily paritions) so when I checked the stats there was everywhere false. And the performance of the compute stats is very poor, it looks like it is scanning partition by partition the tables, and if the partitons is small (on one node) the other nodes are stayin idle.  
Two improvements I would suggest:
 - write the calculated stats immediatly after the partitions stats are gathered
 - if the table has large number of partitoons (3 years, 1000 partitons) scan at least so many partions how many Impala Daemon are configured in parallel.

Thanks