### PR TITLE
modify impala-shell introduction when using LDAP

### DIFF
--- a/shell/impala_shell.py
+++ b/shell/impala_shell.py
@@ -1388,7 +1388,7 @@ if __name__ == "__main__":
 
   intro = WELCOME_STRING
   if not options.ssl and options.creds_ok_in_clear and options.use_ldap:
-    intro += ("\n\\nLDAP authentication is enabled, but the connection to Impala is " +
+    intro += ("\n\nLDAP authentication is enabled, but the connection to Impala is " +
               "not secured by TLS.\nALL PASSWORDS WILL BE SENT IN THE CLEAR TO IMPALA.\n")
 
   shell = ImpalaShell(options)


### PR DESCRIPTION
When using impala-shell with LDAP, introduction has redundant '\n' as following:
\nLDAP authentication is enabled, but the connection to Impala is not secured by TLS.
ALL PASSWORDS WILL BE SENT IN THE CLEAR TO IMPALA.

This PR deletes the redundant '\n' in introduction.

Change-Id: Ic44fe3a72a3a86c85b807959e33b31923c031ab0